### PR TITLE
Updated json dump to indent & not escape non-ascii

### DIFF
--- a/tooling/generate.py
+++ b/tooling/generate.py
@@ -31,5 +31,6 @@ with open("public/delegates.json", "r") as fh:
 delegates.update(delegates_entry)
 
 with open("public/delegates.json", "w") as fh:
-    fh.write(json.dumps(delegates))
+    # Dump with 4 indent and do not escape non-ascii characters
+    fh.write(json.dumps(delegates, indent=4, ensure_ascii=False))
 print("Success. Submit these changes as PR at https://github.com/opentensor/bittensor-delegates")


### PR DESCRIPTION
## Description
I noticed that the `tooling/generate.py` script escaped ascii and did not indent to match the current `delegates.json` file. This should fix it.

Only difference now is that it generates a new line at the end of the file. (did so before as well)