### PR TITLE
Add Taofu

### DIFF
--- a/public/delegates.json
+++ b/public/delegates.json
@@ -304,5 +304,11 @@
         "url": "taostats.io",
         "description": "Supporting bittensor through API access, data provision, statistics, analytics and apps.",
         "signature": "2e2dd0c5f3a3945f29d1be304e64f931c04a23aba7d383d01cd16ea6ca6546002fe3bd95cf8f12cae1fbb7d18d9910b834f6573db219de3ed84073a4e1552e89"
+    },
+    "5ELREhApbCahM7FyGLM1V9WDsnnjCRmMCJTmtQD51oAEqwVh": {
+        "name": "Taofu Protocol",
+        "url": "https://twitter.com/taofuxyz",
+        "description": "Taofu unlocks liquidity and utility by bringing liquid staked TAO outside of Bittensor",
+        "signature": "aaafd3496650a56f798cc587b5b7d372cec8e826a332a34213c1a6ee7be2b5122318858ee73421535d04186cc6976ae5452c6cd1aaf299a307d86d3c52b4a986"
     }
 }


### PR DESCRIPTION
## Description
Taofu unlocks liquidity and utility by bringing liquid-staked TAO outside of Bittensor. The protocol is currently being built. 

## Review Checklist
- [x] All CircleCI checks below are green.
- [x] Only one delegate is modified.