### PR TITLE
Rebrand Staked to Kraken

### DIFF
--- a/public/delegates.json
+++ b/public/delegates.json
@@ -378,9 +378,9 @@
         "signature": "ac874ae7ad9a72bb110660f1bf3d3f2aa8a2152c9ee97087a7c4f9691aad771acc91031eba1bd3e9d5b2884fb845d622c74d51cf767c00f64cfa1bfc11f3008d"
     },
     "5Ft5kRgKDFafWX8mHneYqi44z8J3PGDguVjYnEADxjVJPTih": {
-        "name": "Staked",
-        "url": "https://staked.us",
-        "description": "Staked is the leading provider of validation technology and services.",
+        "name": "Kraken",
+        "url": "https://www.kraken.com/features/staking-coins",
+        "description": "Global crypto adoption by empowering individuals to achieve financial freedom through secure, accessible, and user-focused blockchain services.",
         "signature": "accd6768420e9dc3c6b68fb07f91b662bc7fa5e2d550b1949a0efa8482a43535aafe9ad567fc17ee946915bae69c911ddd833126c0c996fccc67acdcc2f27288"
     },
     "5E2LP6EnZ54m3wS8s1yPvD5c3xo71kQroBw7aUVK32TKeZ5u": {


### PR DESCRIPTION
Rebranding Staked.us to Kraken, to match on-chain identity

https://taostats.io/validators/5Ft5kRgKDFafWX8mHneYqi44z8J3PGDguVjYnEADxjVJPTih